### PR TITLE
Create CI action to test if the service is still running

### DIFF
--- a/.github/workflows/call_qdrant_database.yaml
+++ b/.github/workflows/call_qdrant_database.yaml
@@ -1,0 +1,21 @@
+name: Weekly Query Check
+
+on:
+    schedule:
+        - cron: "0 0 * * 0" # Run every Sunday at midnight
+    workflow_dispatch:
+
+jobs:
+    query_check:
+        runs-on: ubuntu-latest
+
+        steps:
+            - name: Check Query Success
+              run: |
+                response_code=$(curl -s -o /dev/null -w "%{http_code}" "https://ontology-matching.delightfulsand-a1030a48.centralus.azurecontainerapps.io/get_ontology_matches/?text=This%20describes%20a%20behavior%20of%20hunting%20in%20a%20caged%20environment")
+                if [ $response_code -eq 200 ]; then
+                    echo "Query successful"
+                else
+                    echo "Query failed with status code $response_code"
+                    exit 1
+                fi

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ uvicorn app.main:app --reload
 And then test the service by running this:
 
 ```
-curl http://localhost:8000/get_ontology_matches/?text=This%20describes%20a%20behavior%20of%20hunting%20in%20a%20caged%20environment
+curl http://localhost:8000/get_ontology_matches/?text=This%20describes%20a%20behavior%20of%20hunting%20in%20a%20caged%20environment&num_results=10&ontology=neuro_behavior_ontology
 ```
 
 This queries the behavior for `This describes a behavior of hunting in a caged environment`

--- a/app/main.py
+++ b/app/main.py
@@ -117,6 +117,7 @@ async def get_ontology_matches(
     ontology: Optional[Literal["neuro_behavior_ontology", "cognitiveatlas"]] = Query(
         "neuro_behavior_ontology", description="Ontology type to use"
     ),
+    number_of_results: int = Query(5, description="Number of results to return"),
 ):
     api_key = os.environ.get("QDRANT_API_KEY")
     if not api_key:
@@ -144,7 +145,7 @@ async def get_ontology_matches(
         raise HTTPException(status_code=500, detail=str(e))
 
     if results_list:
-        payload_list = [result.payload for result in results_list][:5]
+        payload_list = [result.payload for result in results_list][:number_of_results]
 
     else:
         payload_list = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ontology_matching_service"
-version = "0.1.0"
+version = "0.1.1"
 description = "Your project description"
 authors = [
   {name="Heberto Mayorquin", email="h.mayorquin@gmail.com"}
@@ -21,7 +21,6 @@ classifiers = [
 
 dependencies = [
     "qdrant_client",
-    "langchain==0.0.292",
     "openai==0.27.8",
     "fastapi",
     "uvicorn",

--- a/src/ontology_matching_service/ontology_grounding.py
+++ b/src/ontology_matching_service/ontology_grounding.py
@@ -1,10 +1,8 @@
 import warnings
 import json
-from pathlib import Path
 import os
 
 import openai
-from langchain.embeddings.openai import OpenAIEmbeddings
 from qdrant_client import QdrantClient
 
 from functools import lru_cache
@@ -18,9 +16,12 @@ def get_qdrant_client():
 
 
 def embed_text(text: str) -> list:
-    embedding_model = OpenAIEmbeddings(openai_api_key=os.environ["OPENAI_API_KEY"])
-    embedding = embedding_model.embed_documents([text])[0]
-
+    openai.api_key = os.getenv("OPENAI_API_KEY")
+    response = openai.Embedding.create(
+        input=text,
+        model="text-embedding-ada-002"
+    )
+    embedding = response['data'][0]['embedding']
     return embedding
 
 


### PR DESCRIPTION
This should come after #2 and has it as its base.

Three things:
- Create an action that will avoid the situation of the cluster being taken down for being active too long.
- Remove langchain from dependencies as it is an overkill for callling openai.embeddings and too unstable of an API for that.
- Add another value to the schema so I can be queried directly with the number of results desired from curl or response.